### PR TITLE
feat(config): add configuration management and update documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,4 +24,4 @@ lint:
 	pipenv run flake8 .
 
 test:
-	pipenv run pytest -v .
+	pipenv run pytest -vv .

--- a/Makefile
+++ b/Makefile
@@ -22,3 +22,6 @@ publish: build
 
 lint:
 	pipenv run flake8 .
+
+test:
+	pipenv run pytest -v .

--- a/README.md
+++ b/README.md
@@ -138,6 +138,20 @@ To print all default configs and what is being used, just run:
 gpt-pr-config print
 ```
 
+### Reset config
+
+To reset any config to default value, just run:
+
+```bash
+gpt-pr-config reset config-name
+```
+
+Example:
+
+```bash
+gpt-pr-config reset openai_model
+```
+
 ## Usage
 
 ### Generating Github Pull Requests

--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ GPT-PR is an open-source command-line tool designed to streamline your GitHub wo
 
 - [Features](#features)
 - [Prerequisites](#prerequisites)
-- [Installation and Usage](#installation-and-usage)
-- [Authentication & API Keys](#authentication--api-keys)
+- [Installation](#installation)
+- [Configuration](#configuration)
+- [Usage](#usage)
 - [How to Contribute](#how-to-contribute)
 - [Roadmap](#roadmap)
 
@@ -40,7 +41,7 @@ pip install -U gpt-pr
 
 > Note: Use this command to **update** gpt-pr package to the latest version.
 
-2. Export API keys as environment variables ([Authentication & API Keys](#authentication--api-keys)).
+2. Setup API keys for GitHub and OpenAI, take a look at [Configuration](#configuration).
 
 3. Inside the Git repository you are working on, ensure you have pushed your branch to origin, then run:
 
@@ -63,12 +64,78 @@ cd gpt-pr
 pipenv install
 ```
 
-After exporting api keys as environment variables ([Authentication & API Keys](#authentication--api-keys)), you can use GPT-PR within any git project directory. Suppose you've cloned **this project** to `~/workplace/gpt-pr`, here's how you can use it:
+After setting up API keys ([Configuration](#configuration)), you can use GPT-PR within any git project directory. Suppose you've cloned **this project** to `~/workplace/gpt-pr`, here's how you can use it:
 
 ```bash
 PYTHONPATH=~/workplace/gpt-pr/gpt-pr \
 PIPENV_PIPFILE=~/workplace/gpt-pr/Pipfile \
 pipenv run python ~/workplace/gpt-pr/gptpr/main.py --help
+```
+
+## Configuration
+
+### Setting up GitHub Token (`GH_TOKEN`)
+
+GPT-PR tool will look for a `GH_TOKEN` in current shell env var OR in gpt-pr config file (at `~/.gpt-pr.ini`).
+
+To authenticate with GitHub, generate and export a GitHub Personal Access Token:
+
+1. Navigate to [GitHub's Personal Access Token page](https://github.com/settings/tokens).
+2. Click "Generate new token."
+3. Provide a description and select the required permissions `repo` for the token.
+4. Click "Generate token" at the bottom of the page.
+5. Copy the generated token.
+6. Set `gh_token` config running (supposing your gh token is `ghp_4Mb1QEr9gY5e8Lk3tN1KjPzX7W9z2V4HtJ2b`):
+
+```bash
+gpt-pr-config set gh_token ghp_4Mb1QEr9gY5e8Lk3tN1KjPzX7W9z2V4HtJ2b
+```
+
+Or just export it as an environment variable in your shell initializer:
+
+```bash
+export GH_TOKEN=your_generated_token_here
+```
+
+### Setting up OpenAI API Key (`OPENAI_API_KEY`)
+
+GPT-PR tool will look for a `OPENAI_API_KEY` env var in current shell OR in gpt-pr config file (at `~/.gpt-pr.ini`).
+
+This project needs to interact with the ChatGPT API to generate the pull request description. So, you need to generate and export an OpenAI API Key:
+
+1. Navigate to [OpenAI's API Key page](https://platform.openai.com/signup).
+2. If you don't have an account, sign up and log in.
+3. Go to the API Keys section and click "Create new key."
+4. Provide a description and click "Create."
+5. Copy the generated API key.
+6. Set `openai_api_key` config running (supposing your openai_api_key is `QEr9gY5e8Lk3tN1KjPzX7W9z2V4Ht`):
+
+```bash
+gpt-pr-config set openai_api_key QEr9gY5e8Lk3tN1KjPzX7W9z2V4Ht
+```
+
+Or just export it as an environment variable in your shell initializer:
+
+```bash
+export OPENAI_API_KEY=your_generated_api_key_here
+```
+
+### Change OpenAI model
+
+To change OpenAI model, just run:
+
+```bash
+gpt-pr-config set openai_model gpt-3.5-turbo
+```
+
+To see a full list of available models, access [OpenAI Models Documentation](https://platform.openai.com/docs/models)
+
+### See all configs available
+
+To print all default configs and what is being used, just run:
+
+```bash
+gpt-pr-config print
 ```
 
 ## Usage
@@ -93,38 +160,6 @@ To show help commands:
 
 ```
 gpt-pr -h
-```
-
-## Authentication & API Keys
-
-### Setting up GitHub Token (`GH_TOKEN`)
-
-To authenticate with GitHub, generate and export a GitHub Personal Access Token:
-
-1. Navigate to [GitHub's Personal Access Token page](https://github.com/settings/tokens).
-2. Click "Generate new token."
-3. Provide a description and select the required permissions `repo` for the token.
-4. Click "Generate token" at the bottom of the page.
-5. Copy the generated token.
-6. Export it as an environment variable:
-
-```bash
-export GH_TOKEN=your_generated_token_here
-```
-
-### Setting up OpenAI API Key (`OPENAI_API_KEY`)
-
-This project needs to interact with the ChatGPT API to generate the pull request description. So, you need to generate and export an OpenAI API Key:
-
-1. Navigate to [OpenAI's API Key page](https://platform.openai.com/signup).
-2. If you don't have an account, sign up and log in.
-3. Go to the API Keys section and click "Create new key."
-4. Provide a description and click "Create."
-5. Copy the generated API key.
-6. Export it as an environment variable:
-
-```bash
-export OPENAI_API_KEY=your_generated_api_key_here
 ```
 
 Output:

--- a/gptpr/config.py
+++ b/gptpr/config.py
@@ -3,15 +3,24 @@ import configparser
 import os
 
 
+def config_command_example(name, value_sample):
+    return f'gpt-pr-config set {name} {value_sample}'
+
+
+CONFIG_README_SECTION = 'https://github.com/alissonperez/gpt-pr?tab=readme-ov-file#authentication--api-keys'
+
+
 class Config:
 
     config_filename = '.gpt-pr.ini'
 
     _default_config = {
+        # Github
+        'GH_TOKEN': '',
+
         # Open AI info
         'OPENAI_MODEL': 'gpt-4o',
         'OPENAI_API_KEY': '',
-        'OPENAI_API_KEY_FROM_ENV': 'true',
     }
 
     def __init__(self, config_dir=None):
@@ -67,10 +76,6 @@ class Config:
     def get_user_config(self, name):
         self.load()
         return self._config['user'][name]
-
-    def get_user_config_as_bool(self, name):
-        self.load()
-        return self._config['user'].getboolean(name)
 
     def all_values(self):
         self.load()

--- a/gptpr/config.py
+++ b/gptpr/config.py
@@ -7,7 +7,7 @@ class Config:
 
     config_filename = '.gpt-pr.ini'
 
-    default_config = {
+    _default_config = {
         # Open AI info
         'OPENAI_MODEL': 'gpt-4o',
         'OPENAI_API_KEY': '',
@@ -15,6 +15,7 @@ class Config:
     }
 
     def __init__(self, config_dir=None):
+        self.default_config = deepcopy(self._default_config)
         self._config_dir = config_dir or os.path.expanduser('~')
         self._config = configparser.ConfigParser()
         self._initialized = False
@@ -27,6 +28,7 @@ class Config:
 
         if os.path.exists(config_file_path):
             self._config.read(config_file_path)
+            self._ensure_default_values()
         else:
             self._config['user'] = {}
             self._config['DEFAULT'] = deepcopy(self.default_config)
@@ -34,8 +36,15 @@ class Config:
 
         self._initialized = True
 
-    def exists_config(self):
-        return os.path.exists(self.get_filepath())
+    def _ensure_default_values(self):
+        added = False
+        for key, value in self.default_config.items():
+            if key not in self._config['DEFAULT']:
+                self._config['DEFAULT'][key] = value
+                added = True
+
+        if added:
+            self.persist()
 
     def persist(self):
         config_file_path = self.get_filepath()

--- a/gptpr/gh.py
+++ b/gptpr/gh.py
@@ -1,14 +1,24 @@
 import os
 from github import Github
 from InquirerPy import inquirer
+from gptpr.config import config, config_command_example, CONFIG_README_SECTION
 
-GH_TOKEN = os.environ.get('GH_TOKEN')
 
-if not GH_TOKEN:
-    print("Please set GH_TOKEN environment variable")
-    exit(1)
+def _get_gh_token():
+    gh_token = config.get_user_config('GH_TOKEN')
+    if not gh_token:
+        gh_token = os.environ.get('GH_TOKEN')
 
-gh = Github(GH_TOKEN)
+    if not gh_token:
+        print('Please set "gh_token" config. Just run:',
+              config_command_example('gh_token', '[my gh token]'),
+              'more about at', CONFIG_README_SECTION)
+        exit(1)
+
+    return gh_token
+
+
+gh = Github(_get_gh_token())
 
 
 def create_pr(pr_data, yield_confirmation):

--- a/gptpr/main.py
+++ b/gptpr/main.py
@@ -5,6 +5,8 @@ from gptpr.gitutil import get_branch_info
 from gptpr.gh import create_pr
 from gptpr.prdata import get_pr_data
 from gptpr.version import __version__
+from gptpr.config import config, config_command_example, CONFIG_README_SECTION
+from gptpr import consolecolor as cc
 
 
 def run(base_branch='main', yield_confirmation=False, version=False):
@@ -44,8 +46,51 @@ def run(base_branch='main', yield_confirmation=False, version=False):
     create_pr(pr_data, yield_confirmation)
 
 
+def set_config(name, value):
+    name = name.upper()
+    config.set_user_config(name, value)
+    config.persist()
+
+    print('Config value', cc.bold(name), 'set to', cc.yellow(value))
+
+
+def get_config(name):
+    upper_name = name.upper()
+    print('Config value', cc.bold(name), '=', cc.yellow(config.get_user_config(upper_name)))
+
+
+def reset_config(name):
+    upper_name = name.upper()
+    config.reset_user_config(upper_name)
+    print('Config value', cc.bold(name), '=', cc.yellow(config.get_user_config(upper_name)))
+
+
+def print_config():
+    print('Config values at', cc.yellow(config.get_filepath()))
+    print('')
+    print('To set values, just run:', cc.yellow(config_command_example('[config name]', '[value]')))
+    print('More about at', cc.yellow(CONFIG_README_SECTION))
+    print('')
+    current_section = None
+    for section, option, value in config.all_values():
+        if current_section != section:
+            print('')
+            current_section = section
+
+        print(f'[{cc.bold(section)}]', option, '=', cc.yellow(value))
+
+
 def main():
     fire.Fire(run)
+
+
+def run_config():
+    fire.Fire({
+        'set': set_config,
+        'get': get_config,
+        'print': print_config,
+        'reset': reset_config
+    })
 
 
 if __name__ == '__main__':

--- a/gptpr/prdata.py
+++ b/gptpr/prdata.py
@@ -39,15 +39,14 @@ def _get_pr_template():
 
 
 def _get_open_ai_key():
-    api_key = None
-
-    if config.get_user_config_as_bool('OPENAI_API_KEY_FROM_ENV'):
-        api_key = os.environ.get('OPENAI_API_KEY')
-    else:
-        api_key = config.get_user_config('OPENAI_API_KEY')
+    api_key = config.get_user_config('OPENAI_API_KEY')
 
     if not api_key:
-        print('Please set OPENAI_API_KEY environment variable or config at {config.get_filepath()}.')
+        api_key = os.environ.get('OPENAI_API_KEY')
+
+    if not api_key:
+        print('Please set "openai_api_key" config, just run:',
+              cc.yellow('gpt-pr-config set openai_api_key [open ai key]'))
         exit(1)
 
     return api_key

--- a/gptpr/test_config.py
+++ b/gptpr/test_config.py
@@ -63,18 +63,7 @@ def test_set_user_config(temp_config):
     _check_config(config, temp_dir, [
         ('user', 'OPENAI_MODEL', 'gpt-3.5'),
         ('user', 'OPENAI_API_KEY', ''),
-        ('user', 'OPENAI_API_KEY_FROM_ENV', 'true'),
     ])
-
-
-def test_get_user_config_as_bool(temp_config):
-    config, temp_dir = temp_config
-
-    assert config.get_user_config_as_bool('OPENAI_API_KEY_FROM_ENV') is True
-
-    config.set_user_config('OPENAI_API_KEY_FROM_ENV', 'false')
-
-    assert config.get_user_config_as_bool('OPENAI_API_KEY_FROM_ENV') is False
 
 
 def test_all_values(temp_config):
@@ -83,12 +72,12 @@ def test_all_values(temp_config):
     all_values = config.all_values()
 
     assert all_values == [
+        ('DEFAULT', 'gh_token', ''),
         ('DEFAULT', 'openai_model', 'gpt-4o'),
         ('DEFAULT', 'openai_api_key', ''),
-        ('DEFAULT', 'openai_api_key_from_env', 'true'),
+        ('user', 'gh_token', ''),
         ('user', 'openai_model', 'gpt-4o'),
         ('user', 'openai_api_key', ''),
-        ('user', 'openai_api_key_from_env', 'true')
     ]
 
 
@@ -107,5 +96,4 @@ def test_reset_user_config(temp_config):
     _check_config(config, temp_dir, [
         ('user', 'OPENAI_MODEL', 'gpt-4o'),
         ('user', 'OPENAI_API_KEY', ''),
-        ('user', 'OPENAI_API_KEY_FROM_ENV', 'true'),
     ])

--- a/gptpr/test_config.py
+++ b/gptpr/test_config.py
@@ -1,0 +1,101 @@
+import os
+import configparser
+
+from pytest import fixture
+
+from gptpr.config import Config
+
+
+@fixture
+def temp_config(tmpdir):
+    temp_dir = tmpdir.mkdir('config_dir')
+    config = Config(temp_dir)
+    return config, temp_dir
+
+
+def _check_config(config, temp_dir, config_list):
+    # Read the configuration file and verify its contents
+    config_to_test = configparser.ConfigParser()
+    config_to_test.read(os.path.join(str(temp_dir), config.config_filename))
+
+    for section, key, value in config_list:
+        assert config_to_test[section][key] == value
+
+
+def test_init_config_file(temp_config):
+    config, temp_dir = temp_config
+    config.load()
+
+    # Check if the file exists
+    assert os.path.isfile(os.path.join(str(temp_dir), config.config_filename))
+
+    # Read the configuration file and verify its contents
+    config_to_test = configparser.ConfigParser()
+    config_to_test.read(os.path.join(str(temp_dir), config.config_filename))
+
+    _check_config(config, temp_dir, [
+        ('DEFAULT', 'OPENAI_MODEL', 'gpt-4o'),
+        ('DEFAULT', 'OPENAI_API_KEY', ''),
+        ('DEFAULT', 'OPENAI_API_KEY_FROM_ENV', 'true')
+    ])
+
+
+def test_set_user_config(temp_config):
+    config, temp_dir = temp_config
+
+    config.set_user_config('OPENAI_MODEL', 'gpt-3.5')
+    config.persist()
+
+    # Read the configuration file and verify its contents
+    config_to_test = configparser.ConfigParser()
+    config_to_test.read(os.path.join(str(temp_dir), config.config_filename))
+
+    _check_config(config, temp_dir, [
+        ('user', 'OPENAI_MODEL', 'gpt-3.5'),
+        ('user', 'OPENAI_API_KEY', ''),
+        ('user', 'OPENAI_API_KEY_FROM_ENV', 'true'),
+    ])
+
+
+def test_get_user_config_as_bool(temp_config):
+    config, temp_dir = temp_config
+
+    assert config.get_user_config_as_bool('OPENAI_API_KEY_FROM_ENV') is True
+
+    config.set_user_config('OPENAI_API_KEY_FROM_ENV', 'false')
+
+    assert config.get_user_config_as_bool('OPENAI_API_KEY_FROM_ENV') is False
+
+
+def test_all_values(temp_config):
+    config, temp_dir = temp_config
+
+    all_values = config.all_values()
+
+    assert all_values == [
+        ('DEFAULT', 'openai_model', 'gpt-4o'),
+        ('DEFAULT', 'openai_api_key', ''),
+        ('DEFAULT', 'openai_api_key_from_env', 'true'),
+        ('user', 'openai_model', 'gpt-4o'),
+        ('user', 'openai_api_key', ''),
+        ('user', 'openai_api_key_from_env', 'true')
+    ]
+
+
+def test_reset_user_config(temp_config):
+    config, temp_dir = temp_config
+
+    config.set_user_config('OPENAI_MODEL', 'gpt-3.5')
+    config.persist()
+
+    config.reset_user_config('OPENAI_MODEL')
+
+    # Read the configuration file and verify its contents
+    config_to_test = configparser.ConfigParser()
+    config_to_test.read(os.path.join(str(temp_dir), config.config_filename))
+
+    _check_config(config, temp_dir, [
+        ('user', 'OPENAI_MODEL', 'gpt-4o'),
+        ('user', 'OPENAI_API_KEY', ''),
+        ('user', 'OPENAI_API_KEY_FROM_ENV', 'true'),
+    ])

--- a/gptpr/test_config.py
+++ b/gptpr/test_config.py
@@ -29,14 +29,24 @@ def test_init_config_file(temp_config):
     # Check if the file exists
     assert os.path.isfile(os.path.join(str(temp_dir), config.config_filename))
 
-    # Read the configuration file and verify its contents
-    config_to_test = configparser.ConfigParser()
-    config_to_test.read(os.path.join(str(temp_dir), config.config_filename))
-
     _check_config(config, temp_dir, [
         ('DEFAULT', 'OPENAI_MODEL', 'gpt-4o'),
         ('DEFAULT', 'OPENAI_API_KEY', ''),
-        ('DEFAULT', 'OPENAI_API_KEY_FROM_ENV', 'true')
+    ])
+
+
+def test_new_default_value_should_be_added(temp_config):
+    config, temp_dir = temp_config
+    config.load()  # data was written to the file
+
+    new_config = Config(temp_dir)
+
+    # Add a new default value
+    new_config.default_config['NEW_DEFAULT'] = 'new_default_value'
+    new_config.load()  # Should update config file...
+
+    _check_config(new_config, temp_dir, [
+        ('DEFAULT', 'NEW_DEFAULT', 'new_default_value'),
     ])
 
 

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,10 @@ setup(name='gpt-pr',
       author_email='alissonperez@outlook.com',
       license='MIT',
       entry_points={
-          'console_scripts': ['gpt-pr=gptpr.main:main'],
+          'console_scripts': [
+              'gpt-pr=gptpr.main:main',
+              'gpt-pr-config=gptpr.main:run_config',
+          ],
       },
       packages=find_packages('.'),
       include_package_data=True,


### PR DESCRIPTION
## What was done?
- Added a configuration management system for handling GitHub and OpenAI API keys, as well as other settings.
- Updated the README to reflect the new configuration commands and usage.
- Introduced a new `gpt-pr-config` command for setting, getting, printing, and resetting configuration values.
- Ensured default configuration keys are present in the config file.
- Modified the test Makefile to be verbose.

## How was it done?
The configuration management system was implemented using a new `Config` class that reads and writes to a `.gpt-pr.ini` file in the user's home directory. The class ensures default values are set and provides methods for setting, getting, and resetting configuration values. The `gpt-pr-config` command was added to the `setup.py` entry points to allow users to interact with the configuration system from the command line.

## How was it tested?
- Manual testing was conducted to ensure the `gpt-pr-config` commands work as expected.
- The `gpt-pr` command was tested to verify it correctly reads configuration values from the `.gpt-pr.ini` file.
- The test Makefile was updated to run tests in verbose mode to provide more detailed output.