### PR TITLE
fix(check-version): change to return cached latest version only if valid

### DIFF
--- a/gptpr/checkversion.py
+++ b/gptpr/checkversion.py
@@ -24,7 +24,8 @@ def cache_daily_version(func):
             if datetime.now() - last_checked < CACHE_DURATION:
                 # Use cached version info
                 latest_version = cache.get('latest_version')
-                return latest_version
+                if latest_version:
+                    return latest_version
 
         latest_version = func(*args, **kwargs)
         cache = {


### PR DESCRIPTION
### Ref. None

## What was done?
The function `cache_daily_version` was modified to return the cached latest version only if it is valid (i.e., not None).

## How was it done?
A check was added to ensure that the cached latest version is returned only if it is not None. This prevents the function from returning an invalid cached version.

## How was it tested?
The change was tested by simulating scenarios where the cache contains a valid version, an invalid version (None), and no version at all. The function was observed to return the correct version or proceed to fetch a new version as expected.