### PR TITLE
feat(model): update default model to gpt-4o-mini

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,13 +33,11 @@ You can install and use GPT-PR in one of two ways. Choose the option that best s
 
 ### Option 1: Using `pip install` (Recommended)
 
-1. Install the package:
+1. Install OR Update the package:
 
 ```bash
 pip install -U gpt-pr
 ```
-
-> Note: Use this command to **update** gpt-pr package to the latest version.
 
 2. Setup API keys for GitHub and OpenAI, take a look at [Configuration](#configuration).
 
@@ -49,7 +47,7 @@ pip install -U gpt-pr
 gpt-pr --help
 ```
 
-### Option 2: Cloning the code
+### Option 2: Cloning the code (NOT recommended)
 
 1. Clone the repository:
 
@@ -73,6 +71,14 @@ pipenv run python ~/workplace/gpt-pr/gptpr/main.py --help
 ```
 
 ## Configuration
+
+### See all configs available
+
+To print all default configs and what is being used, just run:
+
+```bash
+gpt-pr-config print
+```
 
 ### Setting up GitHub Token (`GH_TOKEN`)
 
@@ -125,18 +131,12 @@ export OPENAI_API_KEY=your_generated_api_key_here
 To change OpenAI model, just run:
 
 ```bash
-gpt-pr-config set openai_model gpt-3.5-turbo
+gpt-pr-config set openai_model gpt-4o-mini
 ```
+
+> Obs.: `gpt-4o-mini` already is the default model of the project
 
 To see a full list of available models, access [OpenAI Models Documentation](https://platform.openai.com/docs/models)
-
-### See all configs available
-
-To print all default configs and what is being used, just run:
-
-```bash
-gpt-pr-config print
-```
 
 ### Reset config
 

--- a/gptpr/config.py
+++ b/gptpr/config.py
@@ -22,7 +22,7 @@ class Config:
         'INPUT_MAX_TOKENS': '15000',
 
         # Open AI info
-        'OPENAI_MODEL': 'gpt-4o',
+        'OPENAI_MODEL': 'gpt-4o-mini',
         'OPENAI_API_KEY': '',
     }
 

--- a/gptpr/test_config.py
+++ b/gptpr/test_config.py
@@ -30,7 +30,7 @@ def test_init_config_file(temp_config):
     assert os.path.isfile(os.path.join(str(temp_dir), config.config_filename))
 
     _check_config(config, temp_dir, [
-        ('DEFAULT', 'OPENAI_MODEL', 'gpt-4o'),
+        ('DEFAULT', 'OPENAI_MODEL', 'gpt-4o-mini'),
         ('DEFAULT', 'OPENAI_API_KEY', ''),
     ])
 
@@ -89,11 +89,11 @@ def test_all_values(temp_config):
     assert all_values == [
         ('DEFAULT', 'gh_token', ''),
         ('DEFAULT', 'input_max_tokens', '15000'),
-        ('DEFAULT', 'openai_model', 'gpt-4o'),
+        ('DEFAULT', 'openai_model', 'gpt-4o-mini'),
         ('DEFAULT', 'openai_api_key', ''),
         ('user', 'gh_token', ''),
         ('user', 'input_max_tokens', '15000'),
-        ('user', 'openai_model', 'gpt-4o'),
+        ('user', 'openai_model', 'gpt-4o-mini'),
         ('user', 'openai_api_key', ''),
     ]
 
@@ -111,6 +111,6 @@ def test_reset_user_config(temp_config):
     config_to_test.read(os.path.join(str(temp_dir), config.config_filename))
 
     _check_config(config, temp_dir, [
-        ('user', 'OPENAI_MODEL', 'gpt-4o'),
+        ('user', 'OPENAI_MODEL', 'gpt-4o-mini'),
         ('user', 'OPENAI_API_KEY', ''),
     ])


### PR DESCRIPTION
## What was done?
- Updated the default OpenAI model from `gpt-4o` to `gpt-4o-mini` in the configuration.
- Enhanced the README documentation to reflect the changes in installation instructions and model configuration.

## How was it done?
- The default model was changed in the `config.py` file to ensure that new installations use `gpt-4o-mini` by default.
- The README was updated to clarify installation steps and provide additional information on available configurations.

## How was it tested?
- Verified that the changes in the README accurately reflect the new installation and configuration process.
- Tested the application to ensure that it correctly uses the `gpt-4o-mini` model when invoked.