### PR TITLE
fix(git): handle binary files in git diff

### DIFF
--- a/gptpr/gitutil.py
+++ b/gptpr/gitutil.py
@@ -183,10 +183,15 @@ def _get_stats(repo, base_branch, branch):
             continue
 
         line = line.split('\t')
+
+        # Binary files will not have stats (just "-")
+        added = int(line[0]) if line[0] and line[0].isdigit() else 0
+        removed = int(line[1]) if line[1] and line[1].isdigit() else 0
+
         files_changed.append(FileChange(
             file_path=line[2],
-            lines_added=int(line[0]),
-            lines_removed=int(line[1])
+            lines_added=added,
+            lines_removed=removed
         ))
 
     return files_changed


### PR DESCRIPTION
## What was done?
Changed the handling of binary files in the git diff functionality to correctly account for added and removed lines.

## How was it done?
Modified the `_get_stats` function in `gitutil.py` to check for binary files and handle their statistics appropriately. Instead of returning '-' for added and removed lines, the code now checks if the values are digits and assigns them accordingly.

## How was it tested?
Tested the changes by running the updated `_get_stats` function with various repositories containing binary files to ensure that the added and removed lines are calculated correctly.

---

Generated by [GPT-PR](https://github.com/alissonperez/gpt-pr)