### PR TITLE
feat: add git origin parameter to command

### DIFF
--- a/gptpr/gitutil.py
+++ b/gptpr/gitutil.py
@@ -32,7 +32,7 @@ class FileChange:
         return f'{self.file_path} (+{(self.lines_added)} -{self.lines_removed})'
 
 
-def get_branch_info(base_branch, yield_confirmation):
+def get_branch_info(base_branch, origin, yield_confirmation):
     # Get current directory
     current_dir = os.getcwd()
 
@@ -57,7 +57,7 @@ def get_branch_info(base_branch, yield_confirmation):
     if not _branch_exists(repo, base_branch):
         raise Exception(f'Base branch {base_branch} does not exist.')
 
-    owner, repo_name = _get_remote_info(repo)
+    owner, repo_name = _get_remote_info(repo, origin)
 
     commits = _get_diff_messages_against_base_branch(repo, current_branch.name, base_branch)
     commits = _get_valid_commits(commits, yield_confirmation)
@@ -125,9 +125,9 @@ def _get_highlight_commits(commits, yield_confirmation):
     return highlight_commits
 
 
-def _get_remote_info(repo):
+def _get_remote_info(repo, origin):
     for remote in repo.remotes:
-        if remote.name != 'origin':
+        if remote.name != origin:
             continue
 
         remote_urls_joined = ','.join([str(url) for url in remote.urls])
@@ -137,7 +137,7 @@ def _get_remote_info(repo):
         for url in remote.urls:
             return _extract_owner_and_repo(url)
 
-    raise Exception('Could not find origin remote.')
+    raise Exception(f'Could not find \'{origin}\' remote.')
 
 
 def _extract_owner_and_repo(repo_url):

--- a/gptpr/main.py
+++ b/gptpr/main.py
@@ -10,7 +10,7 @@ from gptpr import consolecolor as cc
 from gptpr.checkversion import check_for_updates
 
 
-def run(base_branch='main', yield_confirmation=False, version=False):
+def run(base_branch='main', origin='origin', yield_confirmation=False, version=False):
     '''
     Create Pull Requests from current branch with base branch (default 'main' branch)
     '''
@@ -19,7 +19,7 @@ def run(base_branch='main', yield_confirmation=False, version=False):
         print('Current version:', __version__)
         return
 
-    branch_info = get_branch_info(base_branch, yield_confirmation)
+    branch_info = get_branch_info(base_branch, origin, yield_confirmation)
 
     if not branch_info:
         exit(0)

--- a/gptpr/version.py
+++ b/gptpr/version.py
@@ -1,3 +1,1 @@
-# This file is generated automatically when package is released
-
 __version__ = 'n/d'


### PR DESCRIPTION
### Ref. [Link]

## What was done?
Added a new parameter for the git origin to the command, allowing users to specify which remote repository to interact with.

## How was it done?
The `get_branch_info` and `_get_remote_info` functions were modified to accept an additional `origin` parameter. This change allows the user to specify a remote other than the default 'origin'. The `run` function was also updated to pass this new parameter to `get_branch_info`.

## How was it tested?
- Verified that the command works with the default 'origin' remote.
- Tested with a custom remote name to ensure the functionality is preserved and works as expected.

---

Generated by [GPT-PR](https://github.com/alissonperez/gpt-pr)