### PR TITLE
Add existing PR detection and update flow

### DIFF
--- a/gpt_pr/gh.py
+++ b/gpt_pr/gh.py
@@ -21,11 +21,45 @@ def _get_gh_token():
     return gh_token
 
 
+def _get_existing_pr(repo, branch_name):
+    """Check if a PR already exists for the given branch."""
+    pulls = repo.get_pulls(state="open")
+    for pr in pulls:
+        if pr.head.ref == branch_name:
+            return pr
+    return None
+
+
+def _update_pr(pr, pr_data):
+    """Update an existing PR."""
+    try:
+        pr.edit(title=pr_data.title, body=pr_data.create_body())
+        print(f"Pull request #{pr.number} updated successfully.")
+    except Exception as e:
+        print(f"Failed to update the pull request: {e}")
+        raise SystemExit(1)
+
+
 def create_pr(pr_data, yield_confirmation, gh=None):
     if not gh:
         gh = Github(_get_gh_token())
 
     repo = gh.get_repo(f"{pr_data.branch_info.owner}/{pr_data.branch_info.repo}")
+
+    existing_pr = _get_existing_pr(repo, pr_data.branch_info.branch)
+
+    if existing_pr:
+        update_confirmation = inquirer.confirm(
+            message=f"A pull request for branch '{pr_data.branch_info.branch}' already exists. Do you want to update it?",
+            default=True,
+        ).execute()
+
+        if update_confirmation:
+            _update_pr(existing_pr, pr_data)
+            return
+        else:
+            print("Cancelling...")
+            return
 
     pr_confirmation = (
         yield_confirmation

--- a/gpt_pr/gh.py
+++ b/gpt_pr/gh.py
@@ -49,8 +49,9 @@ def create_pr(pr_data, yield_confirmation, gh=None):
     existing_pr = _get_existing_pr(repo, pr_data.branch_info.branch)
 
     if existing_pr:
+        message = f"A pull request for branch '{pr_data.branch_info.branch}' already exists. Do you want to update it?"
         update_confirmation = inquirer.confirm(
-            message=f"A pull request for branch '{pr_data.branch_info.branch}' already exists. Do you want to update it?",
+            message=message,
             default=True,
         ).execute()
 

--- a/gpt_pr/prdata.py
+++ b/gpt_pr/prdata.py
@@ -43,9 +43,7 @@ Rules:
 - Do not add any explanations, suggestions, or messages directed to the user.
 
 Pull Request Template:
----
 {pr_template}
----
 '''
 
 

--- a/gpt_pr/test_gh.py
+++ b/gpt_pr/test_gh.py
@@ -3,6 +3,7 @@ import gpt_pr.gh as gh_module
 
 
 def test_create_pr_success(mocker, capsys):
+    mocker.patch.object(gh_module, "_get_existing_pr", return_value=None)
     fake_repo = mocker.Mock()
     pr = SimpleNamespace(html_url="http://fake.url")
     fake_repo.create_pull.return_value = pr
@@ -28,6 +29,7 @@ def test_create_pr_success(mocker, capsys):
 
 
 def test_create_pr_cancel(mocker, capsys):
+    mocker.patch.object(gh_module, "_get_existing_pr", return_value=None)
     fake_repo = mocker.Mock()
     fake_gh = SimpleNamespace()
     fake_gh.get_repo = lambda repo_name: fake_repo
@@ -58,3 +60,49 @@ def test_create_pr_cancel(mocker, capsys):
     captured = capsys.readouterr()
 
     assert "cancelling..." in captured.out
+
+
+def test_create_pr_existing_pr_update(mocker, capsys):
+    mock_pr = SimpleNamespace(number=123)
+    mocker.patch.object(gh_module, "_get_existing_pr", return_value=mock_pr)
+    mocker.patch.object(gh_module, "_update_pr")
+    mocker.patch.object(gh_module.inquirer, "confirm", return_value=mocker.Mock(execute=lambda: True))
+
+    fake_repo = mocker.Mock()
+    fake_gh = SimpleNamespace()
+    fake_gh.get_repo = lambda repo_name: fake_repo
+
+    branch_info = SimpleNamespace(
+        owner="owner", repo="repo", branch="feature-branch", base_branch="main"
+    )
+    pr_data = SimpleNamespace(
+        title="Test PR", branch_info=branch_info, create_body=lambda: "My body"
+    )
+
+    gh_module.create_pr(pr_data, yield_confirmation=False, gh=fake_gh)
+
+    gh_module._update_pr.assert_called_once_with(mock_pr, pr_data)
+
+
+def test_create_pr_existing_pr_cancel(mocker, capsys):
+    mock_pr = SimpleNamespace(number=123)
+    mocker.patch.object(gh_module, "_get_existing_pr", return_value=mock_pr)
+    mocker.patch.object(gh_module, "_update_pr")
+    mocker.patch.object(gh_module.inquirer, "confirm", return_value=mocker.Mock(execute=lambda: False))
+    fake_repo = mocker.Mock()
+    fake_gh = SimpleNamespace()
+    fake_gh.get_repo = lambda repo_name: fake_repo
+
+    branch_info = SimpleNamespace(
+        owner="owner", repo="repo", branch="feature-branch", base_branch="main"
+    )
+    pr_data = SimpleNamespace(
+        title="Test PR", branch_info=branch_info, create_body=lambda: "My body"
+    )
+
+    gh_module.create_pr(pr_data, yield_confirmation=False, gh=fake_gh)
+
+    gh_module._update_pr.assert_not_called()
+    fake_repo.create_pull.assert_not_called()
+    captured = capsys.readouterr()
+    assert "Cancelling..." in captured.out


### PR DESCRIPTION
### Ref. [Link]

## What was done?
- Implemented detection of an existing open GitHub pull request for the current branch.
- Added an update flow that prompts the user to either update the existing PR or cancel instead of always creating a new PR.
- Introduced helper functions to find and update existing PRs and added error handling for update failures.
- Removed missing dashes from the PR template area to fix formatting inconsistencies.
- Updated and extended unit tests to cover the new behaviors (existing PR update and cancel flows) and to ensure previous tests still behave correctly.

## How was it done?
- Added _get_existing_pr(repo, branch_name) to return an open pull request whose head ref matches the branch name, or None if none exists.
- Added _update_pr(pr, pr_data) to edit the title and body of an existing PR and to surface failures with a printed message and SystemExit(1).
- Modified create_pr to call _get_existing_pr and, when a PR exists, prompt the user (via inquirer.confirm) to update it. If the user confirms, _update_pr is called; otherwise the operation is canceled.
- Fixed PR template formatting by removing missing dashes in prdata.py to align with the expected template format.
- Tests were updated to mock _get_existing_pr where appropriate and new tests were added to validate both the update and cancel flows for existing PRs.

## How was it tested?
- Unit tests updated/added in gpt_pr/test_gh.py:
  - test_create_pr_success and test_create_pr_cancel now patch _get_existing_pr to return None to ensure the original creation paths are exercised.
  - test_create_pr_existing_pr_update: patches _get_existing_pr to return a mock PR object and patches _update_pr; patches inquirer.confirm to simulate user acceptance (execute() -> True); asserts that _update_pr is called once with the existing PR and pr_data.
  - test_create_pr_existing_pr_cancel: patches _get_existing_pr to return a mock PR object and patches _update_pr; patches inquirer.confirm to simulate user decline (execute() -> False); asserts that _update_pr is not called, no new pull is created, and the cancellation message is printed.
- Tests use mocker, SimpleNamespace, and capsys to simulate GH repo/PR objects, intercept prompts, and capture printed output.
- Runtime behavior: when updating, create_pr calls _update_pr which edits the PR title and body and prints success or failure; failures raise SystemExit(1) after printing the error message.

Significant changes (summary):
- New: _get_existing_pr(repo, branch_name)
- New: _update_pr(pr, pr_data)
- Modified: create_pr to detect existing PRs and prompt for update
- Modified: PR template formatting in prdata.py (removed missing dashes)
- Tests: updated existing tests and added tests for update/cancel flows (gpt_pr/test_gh.py)

---

Generated by [GPT-PR](https://github.com/alissonperez/gpt-pr)